### PR TITLE
Add WAGTAIL_AIRTABLE_TESTING flag to enable the mock API

### DIFF
--- a/tests/settings.py
+++ b/tests/settings.py
@@ -122,6 +122,10 @@ WAGTAILADMIN_BASE_URL = 'http://example.com'
 AIRTABLE_API_KEY = 'keyWoWoWoWoW'
 WAGTAIL_AIRTABLE_ENABLED = True
 WAGTAIL_AIRTABLE_DEBUG = False
+
+# Use the mock Airtable API for testing
+WAGTAIL_AIRTABLE_TESTING = True
+
 AIRTABLE_IMPORT_SETTINGS = {
     'tests.SimplePage': {
         'AIRTABLE_BASE_KEY': 'xxx',

--- a/wagtail_airtable/management/commands/import_airtable.py
+++ b/wagtail_airtable/management/commands/import_airtable.py
@@ -21,7 +21,7 @@ DEFAULT_OPTIONS = {
     "verbosity": 1,
 }
 
-TESTING = any(x in ["test", "runtests.py"] for x in sys.argv)
+TESTING = getattr(settings, "WAGTAIL_AIRTABLE_TESTING", False)
 
 
 class Importer:

--- a/wagtail_airtable/mixins.py
+++ b/wagtail_airtable/mixins.py
@@ -14,7 +14,7 @@ from .tests import MockAirtable
 logger = getLogger(__name__)
 
 
-TESTING = any(x in ["test", "runtests.py"] for x in sys.argv)
+TESTING = getattr(settings, "WAGTAIL_AIRTABLE_TESTING", False)
 
 
 class AirtableMixin(models.Model):


### PR DESCRIPTION
Currently, this line is used to check whether to use the mock Airtable API in place of the real one:

    TESTING = any(x in ["test", "runtests.py"] for x in sys.argv)

I spent far too long wondering why my tests were failing locally, because I was invoking them with `python ./runtests.py` (which doesn't match the above test) instead of `python runtests.py`.

This change makes this more robust, by introducing an explicit `WAGTAIL_AIRTABLE_TESTING` variable in settings - so the mock will be used any time the `tests.settings` settings module is active.