### PR TITLE
Refactor AirtableMixin.create_record and update_record into a single method

### DIFF
--- a/tests/mock_airtable.py
+++ b/tests/mock_airtable.py
@@ -117,6 +117,17 @@ def get_mock_airtable():
                     },
                 },
             ]
+        elif field == "Page Slug" and value == "home":
+            return [
+                {
+                    "id": "recHomePageId",
+                    "fields": {
+                        "title": "Home",
+                        "Page Slug": "home",
+                        "intro": "This is the home page.",
+                    },
+                },
+            ]
         else:
             return []
 

--- a/tests/mock_airtable.py
+++ b/tests/mock_airtable.py
@@ -1,5 +1,6 @@
 """A mocked Airtable API wrapper."""
 from unittest import mock
+from requests.exceptions import HTTPError
 
 def get_mock_airtable():
     """
@@ -14,21 +15,29 @@ def get_mock_airtable():
     MockAirtable.table_name = "app_airtable_advert_base_key"
 
     MockAirtable.get = mock.MagicMock("get")
-    MockAirtable.get.return_value = {
-        "id": "recNewRecordId",
-        "fields": {
-            "title": "Red! It's the new blue!",
-            "description": "Red is a scientifically proven color that moves faster than all other colors.",
-            "external_link": "https://example.com/",
-            "is_active": True,
-            "rating": "1.5",
-            "long_description": "<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Veniam laboriosam consequatur saepe. Repellat itaque dolores neque, impedit reprehenderit eum culpa voluptates harum sapiente nesciunt ratione.</p>",
-            "points": 95,
-            "slug": "red-its-new-blue",
-        },
-    }
+
+    def get_fn(record_id):
+        if record_id == "recNewRecordId":
+            return {
+                "id": "recNewRecordId",
+                "fields": {
+                    "title": "Red! It's the new blue!",
+                    "description": "Red is a scientifically proven color that moves faster than all other colors.",
+                    "external_link": "https://example.com/",
+                    "is_active": True,
+                    "rating": "1.5",
+                    "long_description": "<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Veniam laboriosam consequatur saepe. Repellat itaque dolores neque, impedit reprehenderit eum culpa voluptates harum sapiente nesciunt ratione.</p>",
+                    "points": 95,
+                    "slug": "red-its-new-blue",
+                },
+            }
+        else:
+            raise HTTPError("404 Client Error: Not Found")
+
+    MockAirtable.get.side_effect = get_fn
 
     MockAirtable.insert = mock.MagicMock("insert")
+
     MockAirtable.insert.return_value = {
         "id": "recNewRecordId",
         "fields": {
@@ -62,34 +71,56 @@ def get_mock_airtable():
     MockAirtable.delete.return_value = {"deleted": True, "record": "recNewRecordId"}
 
     MockAirtable.search = mock.MagicMock("search")
-    MockAirtable.search.return_value = [
-        {
-            "id": "recNewRecordId",
-            "fields": {
-                "title": "Red! It's the new blue!",
-                "description": "Red is a scientifically proven color that moves faster than all other colors.",
-                "external_link": "https://example.com/",
-                "is_active": True,
-                "rating": "1.5",
-                "long_description": "<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Veniam laboriosam consequatur saepe. Repellat itaque dolores neque, impedit reprehenderit eum culpa voluptates harum sapiente nesciunt ratione.</p>",
-                "points": 95,
-                "slug": "red-its-new-blue",
-            },
-        },
-        {
-            "id": "Different record",
-            "fields": {
-                "title": "Not the used record.",
-                "description": "This is only used for multiple responses from MockAirtable",
-                "external_link": "https://example.com/",
-                "is_active": False,
-                "rating": "5.5",
-                "long_description": "",
-                "points": 1,
-                "slug": "not-the-used-record",
-            },
-        },
-    ]
+    def search_fn(field, value):
+        if field == "slug" and value == "red-its-new-blue":
+            return [
+                {
+                    "id": "recNewRecordId",
+                    "fields": {
+                        "title": "Red! It's the new blue!",
+                        "description": "Red is a scientifically proven color that moves faster than all other colors.",
+                        "external_link": "https://example.com/",
+                        "is_active": True,
+                        "rating": "1.5",
+                        "long_description": "<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Veniam laboriosam consequatur saepe. Repellat itaque dolores neque, impedit reprehenderit eum culpa voluptates harum sapiente nesciunt ratione.</p>",
+                        "points": 95,
+                        "slug": "red-its-new-blue",
+                    },
+                },
+                {
+                    "id": "Different record",
+                    "fields": {
+                        "title": "Not the used record.",
+                        "description": "This is only used for multiple responses from MockAirtable",
+                        "external_link": "https://example.com/",
+                        "is_active": False,
+                        "rating": "5.5",
+                        "long_description": "",
+                        "points": 1,
+                        "slug": "not-the-used-record",
+                    },
+                },
+            ]
+        elif field == "slug" and value == "a-matching-slug":
+            return [
+                {
+                    "id": "recMatchedRecordId",
+                    "fields": {
+                        "title": "Red! It's the new blue!",
+                        "description": "Red is a scientifically proven color that moves faster than all other colors.",
+                        "external_link": "https://example.com/",
+                        "is_active": True,
+                        "rating": "1.5",
+                        "long_description": "<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Veniam laboriosam consequatur saepe. Repellat itaque dolores neque, impedit reprehenderit eum culpa voluptates harum sapiente nesciunt ratione.</p>",
+                        "points": 95,
+                        "slug": "a-matching-slug",
+                    },
+                },
+            ]
+        else:
+            return []
+
+    MockAirtable.search.side_effect = search_fn
 
     MockAirtable.get_all = mock.MagicMock("get_all")
     MockAirtable.get_all.return_value = [

--- a/tests/models.py
+++ b/tests/models.py
@@ -18,7 +18,7 @@ class SimplePage(AirtableMixin, Page):
     def map_import_fields(cls):
         mappings = {
             "title": "title",
-            "slug": "slug",
+            "Page Slug": "slug",
             "intro": "intro",
         }
         return mappings
@@ -26,7 +26,7 @@ class SimplePage(AirtableMixin, Page):
     def get_export_fields(self):
         return {
             "title": self.title,
-            "slug": self.slug,
+            "Page Slug": self.slug,
             "intro": self.intro,
         }
 

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -130,7 +130,7 @@ AIRTABLE_IMPORT_SETTINGS = {
     'tests.SimplePage': {
         'AIRTABLE_BASE_KEY': 'xxx',
         'AIRTABLE_TABLE_NAME': 'xxx',
-        'AIRTABLE_UNIQUE_IDENTIFIER': 'slug',
+        'AIRTABLE_UNIQUE_IDENTIFIER': {'Page Slug': 'slug'},
         'AIRTABLE_SERIALIZER': 'tests.serializers.SimplePageSerializer',
         'PARENT_PAGE_ID': 'tests.models.get_import_parent_page',
     },

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -200,7 +200,7 @@ class TestImportClass(TestCase):
             "id": "test-created-page-id",
             "fields": {
                 "title": "A simple page",
-                "slug": "a-simple-page",
+                "Page Slug": "a-simple-page",
                 "intro": "How much more simple can it get? And the answer is none. None more simple.",
             },
         }]
@@ -230,7 +230,7 @@ class TestImportClass(TestCase):
                 "id": "test-created-page-id",
                 "fields": {
                     "title": "A simple page",
-                    "slug": "a-simple-page",
+                    "Page Slug": "a-simple-page",
                     "intro": "How much more simple can it get? And the answer is none. None more simple.",
                 },
             }]
@@ -265,7 +265,7 @@ class TestImportClass(TestCase):
             "id": "test-created-page-id",
             "fields": {
                 "title": "A simple page",
-                "slug": "a-simple-page",
+                "Page Slug": "a-simple-page",
                 "intro": "How much more simple can it get? Oh, actually it can get more simple.",
             },
         }]
@@ -299,7 +299,7 @@ class TestImportClass(TestCase):
             "id": "test-created-page-id",
             "fields": {
                 "title": "A simple page",
-                "slug": "a-simple-page",
+                "Page Slug": "a-simple-page",
                 "intro": "How much more simple can it get? And the answer is none. None more simple.",
             },
         }]
@@ -330,7 +330,7 @@ class TestImportClass(TestCase):
             "id": "test-created-page-id",
             "fields": {
                 "title": "A simple page",
-                "slug": "a-simple-page",
+                "Page Slug": "a-simple-page",
                 "intro": "How much more simple can it get? Oh, actually it can get more simple.",
             },
         }]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -144,16 +144,6 @@ class TestAirtableMixin(TestCase):
         advert.airtable_client.insert.assert_not_called()
         self.assertEqual(advert.airtable_record_id, 'recNewRecordId')
 
-    def test_update_record(self):
-        advert = Advert.objects.first()
-        advert.setup_airtable()
-        self.assertEqual(advert.airtable_record_id, '')
-        record = advert.update_record('fake record id')
-        advert.airtable_client.update.assert_called()
-        advert.airtable_client.insert.assert_not_called()
-        self.assertEqual(record['id'], 'recNewRecordId')
-        self.assertEqual(advert.airtable_record_id, 'recNewRecordId')
-
     def test_delete_record(self):
         advert = copy(self.advert)
         advert.setup_airtable()


### PR DESCRIPTION
Fixes #2

`create_record` can actually perform an update (if a record matches by unique identifier) and vice versa (if the instance's `airtable_record_id` is missing from Airtable), and since they call each other it could bounce between them indefinitely if you were particularly unlucky with race conditions. Rewrite this into a single block of logic that runs on both creates and updates:

* if we have an `airtable_record_id` and it exists in Airtable, update that record
* otherwise, if we can find an Airtable record based on unique identifier, update that record and adopt its record ID
* otherwise, create a new Airtable record and adopt its record ID
