### PR TITLE
Support/wagtail 64 upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## unreleased
+
+* Add CI testing for Wagtail 6.4 (Nick Moreton)
+* Ensure CI testing covers all Wagtail/Django versions (Nick Moreton)
+
 ## 1.0.0 (16.12.2024)
 
 * **Breaking**: Callables passed as `PARENT_PAGE_ID` no longer accept an `instance` argument (Matt Westcott)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers=[
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Framework :: Django",
-    "Framework :: Django :: 4",
+    "Framework :: Django :: 4.2",
     "Framework :: Django :: 5.0",
     "Framework :: Django :: 5.1",
     "Framework :: Wagtail",

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,22 @@
 [tox]
+skipsdist = True
+usedevelop = True
+
 envlist =
-    python{3.9,3.10,3.11,3.12,3.13}-django{4.2,5.0,5.1}-wagtail{5.2,6.0,6.1,6.2,6.3}
+    python{3.9,3.10,3.11,3.12}-django4.2-wagtail5.2
+    python{3.10,3.11,3.12}-django5.0-wagtail{5.2,6.3,6.4}
+    python{3.10,3.11,3.12,3.13}-django5.1-wagtail{6.3,6.4}
+
+[gh-actions]
+python =
+    3.9: python3.9
+    3.10: python3.10
+    3.11: python3.11
+    3.12: python3.12
+    3.13: python3.13
 
 [testenv]
+install_command = pip install -e ".[testing]" -U {opts} {packages}
 commands = python runtests.py
 
 basepython =
@@ -15,9 +29,10 @@ basepython =
 deps =
     django4.2: Django>=4.2,<5.0
     django5.0: Django>=5.0,<5.1
-    django5.0: Django>=5.1,<5.2
+    django5.1: Django>=5.1,<5.2
     wagtail5.2: wagtail>=5.2,<6.0
     wagtail6.0: wagtail>=6.0,<6.1
     wagtail6.1: wagtail>=6.1,<6.2
     wagtail6.2: wagtail>=6.2,<6.3
     wagtail6.3: wagtail>=6.3,<6.4
+    wagtail6.4: wagtail>=6.4,<6.5


### PR DESCRIPTION
This pull request includes updates to the CI testing configuration and dependencies for Django and Wagtail versions.

Updates to CI testing configuration and dependencies:

* Added entries for CI testing for Wagtail 6.4 and comprehensive coverage for all Wagtail/Django versions.
* Added `skipsdist` and `usedevelop` options, updated `envlist` to include new testing configurations, added `gh-actions` section for GitHub Actions, and updated `deps` to include Wagtail 6.4. 

Updates to supported Django versions:

* Updated the classifier for Django to specify version 4.2.

I noticed that the CI testing wasn't covering / installing the matrix versions of Wagtail/Django. Hence the majority of the changes are top make the CI testing cover all combinations.