### PR TITLE
Wagtail 70 maintenance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## unreleased
+
+* Add CI testing for Wagtail 6.4 (Nick Moreton)
+* Ensure CI testing covers all Wagtail/Django versions (Nick Moreton)
+
 ## 1.0.0 (16.12.2024)
 
 * **Breaking**: Callables passed as `PARENT_PAGE_ID` no longer accept an `instance` argument (Matt Westcott)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## unreleased
 
+* Drop CI testing for Django 5.0 (Nick Moreton)
+* Add CI testing for Django 5.2 (Nick Moreton)
+* Drop CI testing for Wagtail 6.0, 6.1 & 6.2 (Nick Moreton)
+* Add CI testing for Wagtail 7.0 (Nick Moreton)
 * Add CI testing for Wagtail 6.4 (Nick Moreton)
 * Ensure CI testing covers all Wagtail/Django versions (Nick Moreton)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers=[
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Framework :: Django",
-    "Framework :: Django :: 4",
+    "Framework :: Django :: 4.2",
     "Framework :: Django :: 5.0",
     "Framework :: Django :: 5.1",
     "Framework :: Wagtail",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,14 +23,15 @@ classifiers=[
     "Programming Language :: Python :: 3.13",
     "Framework :: Django",
     "Framework :: Django :: 4.2",
-    "Framework :: Django :: 5.0",
     "Framework :: Django :: 5.1",
+    "Framework :: Django :: 5.2",
     "Framework :: Wagtail",
     "Framework :: Wagtail :: 5",
     "Framework :: Wagtail :: 6",
+    "Framework :: Wagtail :: 7",
 ]
 
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
     "Wagtail>=5.2",
     "Django>=4.2",

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,22 @@
 [tox]
+skipsdist = True
+usedevelop = True
+
 envlist =
-    python{3.9,3.10,3.11,3.12,3.13}-django{4.2,5.0,5.1}-wagtail{5.2,6.0,6.1,6.2,6.3}
+    python{3.9,3.10,3.11,3.12}-django4.2-wagtail5.2
+    python{3.10,3.11,3.12}-django5.0-wagtail{5.2,6.3,6.4}
+    python{3.10,3.11,3.12,3.13}-django5.1-wagtail{6.3,6.4}
+
+[gh-actions]
+python =
+    3.9: python3.9
+    3.10: python3.10
+    3.11: python3.11
+    3.12: python3.12
+    3.13: python3.13
 
 [testenv]
+install_command = pip install -e ".[testing]" -U {opts} {packages}
 commands = python runtests.py
 
 basepython =
@@ -15,9 +29,10 @@ basepython =
 deps =
     django4.2: Django>=4.2,<5.0
     django5.0: Django>=5.0,<5.1
-    django5.0: Django>=5.1,<5.2
+    django5.1: Django>=5.1,<5.2
     wagtail5.2: wagtail>=5.2,<6.0
     wagtail6.0: wagtail>=6.0,<6.1
     wagtail6.1: wagtail>=6.1,<6.2
     wagtail6.2: wagtail>=6.2,<6.3
     wagtail6.3: wagtail>=6.3,<6.4
+    wagtail6.4: wagtail>=6.4,<6.5

--- a/tox.ini
+++ b/tox.ini
@@ -3,9 +3,8 @@ skipsdist = True
 usedevelop = True
 
 envlist =
-    python{3.9,3.10,3.11,3.12}-django4.2-wagtail5.2
-    python{3.10,3.11,3.12}-django5.0-wagtail{5.2,6.3,6.4}
-    python{3.10,3.11,3.12,3.13}-django5.1-wagtail{6.3,6.4}
+    python{3.9,3.10,3.11,3.12}-django4.2-wagtail{5.2,6.3,6.4,7.0}
+    python{3.10,3.11,3.12,3.13}-django{5.1,5.2}-wagtail{6.3,6.4,7.0}
 
 [gh-actions]
 python =
@@ -28,11 +27,9 @@ basepython =
 
 deps =
     django4.2: Django>=4.2,<5.0
-    django5.0: Django>=5.0,<5.1
     django5.1: Django>=5.1,<5.2
+    django5.2: Django>=5.2,<5.3
     wagtail5.2: wagtail>=5.2,<6.0
-    wagtail6.0: wagtail>=6.0,<6.1
-    wagtail6.1: wagtail>=6.1,<6.2
-    wagtail6.2: wagtail>=6.2,<6.3
     wagtail6.3: wagtail>=6.3,<6.4
     wagtail6.4: wagtail>=6.4,<6.5
+    wagtail7.0: wagtail>=7.0,<7.1


### PR DESCRIPTION
This pull request updates CI & test configurations.

Includes: https://github.com/wagtail-nest/wagtail-airtable/pull/78

### CI and Testing Updates:
* Updated `tox.ini` to reflect new testing environments, dropping support for Django 5.0 and Wagtail 6.0–6.2 while adding support for Django 5.2 and Wagtail 6.4 and 7.0

### Dependency and Metadata Updates:
* Updated `pyproject.toml` to reflect the new supported versions of Django (4.2, 5.1, 5.2) and Wagtail (6.4, 7.0). Increased the minimum Python version requirement to 3.9.

### Documentation Updates:
* Updated `CHANGELOG.md` to document the changes in CI testing coverage and framework support.