### PR TITLE
Wagtail 72 maintenance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* Wagtail 7.2 maintenance
 * Wagtail 7.0 & 7.1 maintenance
 
 ## 1.0.0 (16.12.2024)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* Wagtail 7.0 & 7.1 maintenance
+
 ## 1.0.0 (16.12.2024)
 
 * **Breaking**: Callables passed as `PARENT_PAGE_ID` no longer accept an `instance` argument (Matt Westcott)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers=[
 
 requires-python = ">=3.10"
 dependencies = [
-    "Wagtail>=6.3",
+    "Wagtail>=7.0",
     "Django>=4.2",
     "pyairtable>=3,<4",
     "djangorestframework>=3.16.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,11 +16,11 @@ classifiers=[
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Framework :: Django",
     "Framework :: Django :: 4.2",
     "Framework :: Django :: 5.1",
@@ -31,7 +31,7 @@ classifiers=[
     "Framework :: Wagtail :: 7",
 ]
 
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
     "Wagtail>=6.3",
     "Django>=4.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,25 +22,26 @@ classifiers=[
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Framework :: Django",
-    "Framework :: Django :: 4",
-    "Framework :: Django :: 5.0",
+    "Framework :: Django :: 4.2",
     "Framework :: Django :: 5.1",
+    "Framework :: Django :: 5.2",
     "Framework :: Wagtail",
     "Framework :: Wagtail :: 5",
     "Framework :: Wagtail :: 6",
+    "Framework :: Wagtail :: 7",
 ]
 
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
-    "Wagtail>=5.2",
+    "Wagtail>=6.3",
     "Django>=4.2",
-    "pyairtable>=2.3,<3",
-    "djangorestframework>=3.11.0"
+    "pyairtable>=3,<4",
+    "djangorestframework>=3.16.1"
 ]
 
 [project.optional-dependencies]
 testing = [
-    "tox>=3.27"
+    "tox>=4.30.2"
 ]
 
 [project.urls]

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 [tox]
 envlist =
-    python{3.9,3.10,3.11,3.12,3.13}-django{4.2,5.0,5.1}-wagtail{5.2,6.0,6.1,6.2,6.3}
+    python{3.9,3.10,3.11,3.12}-django{4.2}-wagtail{6.3,7.0,7.1}
+    python{3.10,3.11,3.12,3.13}-django{5.1,5.2}-wagtail{6.3,7.0,7.1}
 
 [testenv]
 commands = python runtests.py
@@ -14,10 +15,8 @@ basepython =
 
 deps =
     django4.2: Django>=4.2,<5.0
-    django5.0: Django>=5.0,<5.1
-    django5.0: Django>=5.1,<5.2
-    wagtail5.2: wagtail>=5.2,<6.0
-    wagtail6.0: wagtail>=6.0,<6.1
-    wagtail6.1: wagtail>=6.1,<6.2
-    wagtail6.2: wagtail>=6.2,<6.3
+    django5.1: Django>=5.1,<5.2
+    django5.2: Django>=5.2,<5.3
     wagtail6.3: wagtail>=6.3,<6.4
+    wagtail7.0: wagtail>=7.0,<7.1
+    wagtail7.1: wagtail>=7.1,<7.2

--- a/tox.ini
+++ b/tox.ini
@@ -1,22 +1,22 @@
 [tox]
 envlist =
-    python{3.9,3.10,3.11,3.12}-django{4.2}-wagtail{6.3,7.0,7.1}
-    python{3.10,3.11,3.12,3.13}-django{5.1,5.2}-wagtail{6.3,7.0,7.1}
+    python{3.10,3.11,3.12}-django{4.2,5.1,5.2}-wagtail{7.0,7.2}
+    python{3.13}-django{5.1,5.2}-wagtail{7.0,7.2}
+    python{3.14}-django{5.2}-wagtail{7.0,7.2}
 
 [testenv]
 commands = python runtests.py
 
 basepython =
-    python3.9: python3.9
     python3.10: python3.10
     python3.11: python3.11
     python3.12: python3.12
     python3.13: python3.13
+    python3.14: python3.14
 
 deps =
     django4.2: Django>=4.2,<5.0
     django5.1: Django>=5.1,<5.2
     django5.2: Django>=5.2,<5.3
-    wagtail6.3: wagtail>=6.3,<6.4
     wagtail7.0: wagtail>=7.0,<7.1
-    wagtail7.1: wagtail>=7.1,<7.2
+    wagtail7.2: wagtail>=7.2,<7.3


### PR DESCRIPTION
Builds off of #80 

**Dependency and compatibility updates:**

* Updated minimum supported Python version to 3.10 and added support up to Python 3.14, removing Python 3.9 support. 
* Updated minimum Wagtail requirement to Wagtail 7.0 and add testing for 7.2,
* Updated project classifiers to reflect new Python, Django, and Wagtail version support.
* Added changelog entries for Wagtail 7.0 and 7.2 maintenance.